### PR TITLE
Add shebang to start.sh

### DIFF
--- a/Compiled/start.sh
+++ b/Compiled/start.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 if [ "$#" -eq 1 ] && [ "$1" = "-d" ]; then
     echo "DEBUG"
     java -classpath UnrealEngineLauncher.jar launcher.Main -d


### PR DESCRIPTION
Executing `./start.sh` only works from `sh` or `bash`, and does not work on others like `fish`. With the shebang it will be executable with any configuration.